### PR TITLE
Add queues and subscriptions for minimal and parsing version.

### DIFF
--- a/lib/hets-rabbitmq-wrapper.rb
+++ b/lib/hets-rabbitmq-wrapper.rb
@@ -7,18 +7,42 @@ module HetsRabbitMQWrapper
   def self.run
     connection = Bunny.new
     connection.start
-    channel = connection.create_channel
-    # worker will only accept one message at time
-    channel.prefetch(1)
-    request_queue =
-      channel.queue('hets-request', durable: true, auto_delete: false)
-    result_queue = channel.queue('hets-result')
 
-    request_queue.subscribe(manual_ack: true,
-                            block: true,
-                            timeout: 0) do |delivery_info, _properties, _body|
-      # TODO: push body to hets
-      channel.ack(delivery_info.delivery_tag)
+    min_parsing_version(connection)
+  end
+
+  def self.instance_version
+    #get version from HetsInstance
+  end
+
+  def self.min_parsing_version(connection)
+    channel = connection.create_channel
+    channel.exchange_declare('ex_min_parsing_version', 'x-recent-history',
+                             {'x-recent-history-length' => 1})
+    q_min_parsing_version = channel.queue('q_min_parsing_version',
+                                          durable: true, auto_delete: false)
+    q_min_parsing_version.bind('ex_min_parsing_version')
+    q_min_parsing_version.
+      subscribe(block: false,
+                timeout: 0) do |delivery_info, properties, version|
+      subscribe(version, connection)
+    end
+  end
+
+  def self.subscribe(version, connection)
+    channel = connection.create_channel
+    channel.prefetch(1)
+    queues = Hash.new
+    queues["#{version}"] = channel.queue("parsing-version-#{version}",
+                                         auto_delete: true)
+    puts queues["#{version}"]
+    if version.to_i <= instance_version.to_i
+      queues["#{version}"].
+        subscribe(block: false, manual_ack: true,
+                  timeout: 0) do |delivery_info, properties, body|
+        channel.ack(delivery_info.delivery_tag)
+        #push body to hets
+      end
     end
   end
 end

--- a/lib/hets-rabbitmq-wrapper.rb
+++ b/lib/hets-rabbitmq-wrapper.rb
@@ -4,44 +4,64 @@ require 'hets-rabbitmq-wrapper/version'
 require 'bunny'
 
 module HetsRabbitMQWrapper
-  def self.run
-    connection = Bunny.new
-    connection.start
-
-    min_parsing_version(connection)
-  end
-
-  def self.instance_version
-    # get version from HetsInstance
-  end
-
-  def self.min_parsing_version(connection)
-    channel = connection.create_channel
-    channel.exchange_declare('ex_min_parsing_version', 'x-recent-history',
-                             'x-recent-history-length' => 1)
-    q_min_parsing_version = channel.queue('q_min_parsing_version',
-                                          durable: true, auto_delete: false)
-    q_min_parsing_version.bind('ex_min_parsing_version')
-    q_min_parsing_version.
-      subscribe(block: false,
-                timeout: 0) do |_delivery_info, _properties, version|
-      subscribe(version, connection)
+  # Delivers queues for messages and decision which queues should be subscribed
+  class Subscriber
+    def initialize
+      @connection = Bunny.new
     end
-  end
 
-  def self.subscribe(version, connection)
-    channel = connection.create_channel
-    channel.prefetch(1)
-    queues = {}
-    queues[version.to_s] = channel.queue("parsing-version-#{version}",
-                                         auto_delete: true)
-    if version.to_i <= instance_version.to_i
-      queues[version.to_s].
-        subscribe(block: false, manual_ack: true,
-                  timeout: 0) do |delivery_info, _properties, _body|
-        channel.ack(delivery_info.delivery_tag)
-        # push body to hets
+    def call
+      @connection.start
+      subscribe_min_parsing_version_queue
+    ensure
+      @connection.close
+    end
+
+    private
+
+    # get version from HetsInstance
+    def instance_version
+      # TODO: get version from HetsInstance
+    end
+
+    # Binds queue to exchange and subscribes to mininmal parsing version queue
+    def subscribe_min_parsing_version_queue
+      q_min_parsing_version = min_parsing_version_queue
+      q_min_parsing_version.bind('ex_min_parsing_version')
+      q_min_parsing_version.
+        subscribe(block: true,
+                  timeout: 0) do |_delivery_info, _properties, version|
+        subscribe_worker_queue(version)
       end
+    end
+
+    # Creates an exchange and a queue for minimal parsing version
+    def min_parsing_version_queue
+      channel = @connection.create_channel
+      channel.exchange_declare('ex_min_parsing_version', 'x-recent-history',
+                               'x-recent-history-length' => 1)
+      channel.queue('q_min_parsing_version', durable: true, auto_delete: false)
+    end
+
+    # Subscribes to worker queue if min version is <= own version
+    def subscribe_worker_queue(version)
+      queues = create_worker_queue(version)
+      if version.to_i <= instance_version.to_i
+        queues[version.to_s].
+          subscribe(block: false, manual_ack: true,
+                    timeout: 0) do |delivery_info, _properties, _body|
+          channel.ack(delivery_info.delivery_tag)
+          # TODO: push body to hets
+        end
+      end
+    end
+
+    # Creates a worker queue depending on the min parsing version
+    def create_worker_queue(version)
+      channel = @connection.create_channel
+      channel.prefetch(1)
+      {version.to_s => channel.queue("parsing-version-#{version}",
+                                     auto_delete: true)}
     end
   end
 end


### PR DESCRIPTION
This should fix #2.

This PR adds
* the `q_min_parsing_version` (which is bound to the exchange `ex_min_parsing_version`) queue to which Ontohub will announce its required minimal version. All queues listen to it and
* subscribe to a corresponding queue IF the version is `<=` then the version of the Hets instance

Example:
A consumer with version `2.5` listens to `q_min_parsing_version`. Ontohub announces the version `1.3` and `4.5`. The consumer receives `1.3` and `4.5`, but only subscribes to `1.3`. A queue for `4.5` will be created nonetheless.